### PR TITLE
Way faster JPEG storage (espacially on slow devices)

### DIFF
--- a/v4l2grab.c
+++ b/v4l2grab.c
@@ -136,7 +136,11 @@ static void jpegWrite(unsigned char* img)
 	cinfo.image_width = width;
 	cinfo.image_height = height;
 	cinfo.input_components = 3;
+#if defined(JPG_YUV)
+	cinfo.in_color_space = JCS_YCbCr;
+#else
 	cinfo.in_color_space = JCS_RGB;
+#endif
 
 	// set jpeg compression parameters to default
 	jpeg_set_defaults(&cinfo);
@@ -170,6 +174,9 @@ static void imageProcess(const void* p)
 	unsigned char* src = (unsigned char*)p;
 	unsigned char* dst = malloc(width*height*3*sizeof(char));
 
+#if defined(JPG_YUV)
+    YUV420toRGB888(width,height,src,dst);
+#else
 	switch (pixelformat) {
 		case V4L2_PIX_FMT_YUV420:
 			// convert from YUV420 to RGB888
@@ -185,6 +192,7 @@ static void imageProcess(const void* p)
 			fprintf(stderr, "Pixelformat of device not supported!\n");
 			exit(-1);
 	}
+#endif
 
 	// write jpeg
 	jpegWrite(dst);

--- a/yuv.c
+++ b/yuv.c
@@ -135,3 +135,38 @@ void YUV420toRGB888(int width, int height, unsigned char *src, unsigned char *ds
 		}
 	}
 }
+
+/**
+	Convert from YUV420 format to YUV444.
+
+	\param width width of image
+	\param height height of image
+	\param src source
+	\param dst destination
+*/
+void YUV422toYUV444(int width, int height, unsigned char* src, unsigned char* dst) {
+	int line, column;
+	unsigned char *py, *pu, *pv;
+	unsigned char *tmp = dst;
+
+	  py = src;
+	  pu = src + 1;
+	  pv = src + 3;
+
+	for (line = 0; line<height; line++) {
+		for (column = 0; column<width; column++) {
+			*tmp++ = *py;
+			*tmp++ = *pu;
+			*tmp++ = *pv;
+
+		      // increase py every time
+		      py += 2;
+		      // increase pu,pv every second time
+		      if ((column & 1)==1) {
+		        pu += 4;
+		        pv += 4;
+		      }
+		}
+	}
+}
+

--- a/yuv.h
+++ b/yuv.h
@@ -3,5 +3,6 @@
 
 void YUV422toRGB888(int width, int height, unsigned char *src, unsigned char *dst);
 void YUV420toRGB888(int width, int height, unsigned char *src, unsigned char *dst);
+void YUV422toYUV444(int width, int height, unsigned char* src, unsigned char* dst);
 
 #endif


### PR DESCRIPTION
Added YUV422toYUV444 conversion.
This is way faster on Slow CPUs like on Raspberry Pi, if you e.g. want
to capture as much photos as possible in a loop.

Maybe someone can find a more elegant way than a compile-flag to use this.
